### PR TITLE
Fix exception when the game finishes.

### DIFF
--- a/egg_catcher.py
+++ b/egg_catcher.py
@@ -1,3 +1,4 @@
+import sys
 from itertools import cycle
 from random import randrange
 from tkinter import Tk , Canvas , messagebox , font
@@ -59,6 +60,7 @@ def egg_dropped(egg):
     if lives_remaning == 0:
         messagebox.showinfo('GAME OVER!' , 'Final Score : ' + str(score))
         win.destroy()
+        sys.exit(0)
 
 def lose_a_life():
     global lives_remaning


### PR DESCRIPTION
Fix exception when the game finishes:

```
Exception in Tkinter callback
Traceback (most recent call last):
  File "C:\Users\sotan\Anaconda3\lib\tkinter\__init__.py", line 1705, in __call__
    return self.func(*args)
  File "C:\Users\sotan\Anaconda3\lib\tkinter\__init__.py", line 749, in callit
    func(*args)
  File "C:/Users/sotan/PycharmProjects/EGG-CATCHER/egg_catcher.py", line 49, in move_eggs
    (egg_x,egg_y,egg_x2,egg_y2) = c.coords(egg)
  File "C:\Users\sotan\Anaconda3\lib\tkinter\__init__.py", line 2469, in coords
    self.tk.call((self._w, 'coords') + args))]
_tkinter.TclError: invalid command name ".!canvas"
```

It happens because the TKinter window is destroyed, but the program continues running and tries to get more information from the erased window.